### PR TITLE
Alternate Callback on Completion

### DIFF
--- a/helium.js
+++ b/helium.js
@@ -5,6 +5,8 @@
 
 var helium = {
 
+    callback : undefined,
+
 	data:{
 		//timeout
 		//status,
@@ -18,7 +20,9 @@ var helium = {
 
 
 	init:function(){
-
+        // Callback on init or default to running the report.
+        helium.callback = (arguments.length > 0) ? arguments[0] : helium.report;
+        
         //silently fail if localStorage is not available
         if( window.localStorage ){
 
@@ -117,7 +121,7 @@ var helium = {
 		
 		if( helium.data.status === 4 ){
 			//Finished, issue report
-			helium.report();
+			helium.callback();
 		}
 		
 		
@@ -335,8 +339,8 @@ var helium = {
 				helium.data.status = 4;
 				helium.save();
 				
-				//do report
-				helium.report();
+				//run callback
+				helium.callback();
 
 			}
 			


### PR DESCRIPTION
I was using helium for a little personal webapp I'm writing and found the need to have helium execute a callback on completion and so I made these small modifications. The only difference it makes is allowing **helium.init** to be called as:

``` javascript
    helium.init(function() { ... });
```

If **helium.init** doesn't receive a function as an argument, it will just default to it's normal behavior of running the report.

Just noticed that my IDE automatically converted the indents to tabs. If that's a problem, I can go through and convert them back.
