### PR TITLE
Give the selectors array a default value

### DIFF
--- a/helium.js
+++ b/helium.js
@@ -470,6 +470,9 @@ var helium = {
 				//parse selectors. ##NEWLINE REMOVAL IS HACKISH, CAN BE DONE BETTER WITH A BETTER REGEX
 				var selectors = data.replace(/\n/g,'').match(/[^\}]+[\.\#\-\w]?(?=\{)/gim);
 
+				//prevent crash if there is a problem with the stylesheet
+				selectors = selectors || [];
+				
 				//results of selector tests
 				var results = [];
 


### PR DESCRIPTION
If a stylesheet cannot be loaded/parsed correctly, the selectors array can end up as undefined, causing the for loop to crash when checking its condition.

This change lets helium run, even if some stylesheets cannot be parsed.
